### PR TITLE
Update package.json to be APIv1.0-compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "linter-js-standard",
   "main": "./lib/init",
   "linter-package": true,
-  "activationEvents": [],
+  "activationCommands": [],
   "version": "0.2.1",
   "description": "Linter plugin for JavaScript Standard Style",
   "repository": "https://github.com/ricardofbarros/linter-js-standard.git",


### PR DESCRIPTION
`activationEvents` was deprecated in favor of `activationCommands`. The field is empty — probably because this package is invoked by the linter, and not by the user, and so a straight s/activationCommands/activationEvents seems to work fine, and eliminates the warning in DeprecationCop.

Closes #5.