### PR TITLE
Fixes #19: Add happiness as a third style option

### DIFF
--- a/lib/bin-path.coffee
+++ b/lib/bin-path.coffee
@@ -12,3 +12,9 @@ module.exports =
     'node_modules',
     'semistandard',
     'bin'
+
+  happiness: path.join __dirname,
+    '..',
+    'node_modules',
+    'happiness',
+    'bin'

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -5,7 +5,7 @@ module.exports =
     style:
       type: 'string'
       default: 'standard'
-      enum: ['standard', 'semi-standard']
+      enum: ['standard', 'semi-standard', 'happiness']
     checkStyleDevDependencies:
       type: 'boolean'
       description: 'Check code style on package.json devDependencies'

--- a/lib/linter-js-standard.coffee
+++ b/lib/linter-js-standard.coffee
@@ -61,6 +61,9 @@ class LinterJsStandard extends Linter
       if config.style == 'standard'
         @linterName = 'js-standard'
         @executablePath = binPath.standard
+      else if config.style == 'happiness'
+        @linterName = 'js-happiness'
+        @executablePath = binPath.happiness
       else
         @linterName = 'js-semistandard'
         @executablePath = binPath.semiStandard
@@ -96,6 +99,12 @@ class LinterJsStandard extends Linter
         @linterName = 'js-standard'
         @executablePath = binPath.standard
 
+      else if devDeps.happiness
+        # Set execPath to happiness bin
+        # and change linter name
+        @linterName = 'js-happiness'
+        @executablePath = binPath.happiness
+
       else
         # Set execPath to semistandard bin
         # and change linter name
@@ -126,6 +135,9 @@ class LinterJsStandard extends Linter
       styleSettings = pkgConfig(null, options)
     else if @linterName == 'js-semistandard'
       options.root = 'semistandard'
+      styleSettings = pkgConfig(null, options)
+    else if @linterName == 'js-happiness'
+      options.root = 'happiness'
       styleSettings = pkgConfig(null, options)
 
     if styleSettings

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "esprima": "^2.4.1",
     "esprima-fb": "^15001.1.0-dev-harmony-fb",
     "find-root": "^0.1.1",
+    "happiness": "^1.0.7",
     "minimatch": "^2.0.8",
     "pkg-config": "^1.1.0",
     "semistandard": "^6.1.1",


### PR DESCRIPTION
I like this module, but I use tabs and semicolons when writing ES6 - [happiness](https://github.com/JedWatson/happiness) is a fork of `standard`/`semi-standard` that enforces those rules out-of-the-box, so I figured it would make a good addition to this linter.

@ricardofbarros Apologies if I've messed anything up here - this is actually the first time I've tried submitting a PR to a CoffeeScript project :)

_Edit: happiness issue: JedWatson/happiness#3_