### PR TITLE
Linting stdin rather than reading the file again

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -84,19 +84,16 @@ module.exports = {
   __cacheFileSettings: function (config, textEditor) {
     var filePath = textEditor.getPath()
     var styleObj = selectStyle(config, filePath)
-    var args = ['--verbose', filePath]
 
     // If setting honorStyleSettings is checked
     // and there is a valid linter
     if (config.honorStyleSettings && styleObj.name !== 'no-style') {
-      // This function may modifiy the following variables:
-      // - args
-      // - styleObj
-      styleSettings.call({ args: args, styleObj: styleObj }, filePath)
+      // This function may modify styleObj
+      styleSettings.call({ styleObj: styleObj }, filePath)
     }
 
-    // Cache style settings and args of some file
-    this.cache.set(filePath, { styleObj: styleObj, args: args})
+    // Cache style settings of some file
+    this.cache.set(filePath, { styleObj: styleObj })
   },
   provideLinter: require('./linter-js-standard')
 }

--- a/lib/linter-js-standard.js
+++ b/lib/linter-js-standard.js
@@ -12,7 +12,7 @@ module.exports = function () {
     scope: 'file',
     lintOnFly: true,
     regex:
-      '^(?<file>.*?\\..*?(?=:))' +
+      '^(?<file>.*?(?=:))' +
       ':(?<line>[0-9]+):(?<col>[0-9]+):' +
       '((?<message>.*?(?=\\())((?<error>.+undefined.*?)|(?<warning>.*?)))$',
     lint: function (textEditor) {
@@ -21,7 +21,7 @@ module.exports = function () {
       var settings = self.cache.get(filePath)
 
       // Sane check
-      if (!settings || !settings.args || !settings.styleObj) {
+      if (!settings || !settings.styleObj) {
         atom.notifications.addWarning('Something went wrong internally.', {
           detail: 'No sweat, just re-open this file and this annoying warning shouldn\'t appear anymore',
           dismissable: true
@@ -30,8 +30,7 @@ module.exports = function () {
         return []
       }
 
-      var args = settings.args.filter(function () { return true })
-      var bindedLinter = linter.bind({
+      var boundLinter = linter.bind({
         regex: this.regex,
         file: {
           path: filePath,
@@ -39,8 +38,12 @@ module.exports = function () {
         }
       })
 
-      return helpers.execNode(settings.styleObj.execPath, args)
-      .then(bindedLinter)
+      var execPath = settings.styleObj.execPath
+      var args = ['--verbose', '-']
+      var opts = { stdin: fileContent }
+
+      return helpers.execNode(execPath, args, opts)
+      .then(boundLinter)
       .catch(function (err) {
         atom.notifications.addError('Couldn\'t execute linter bin', {
           detail: err.message,


### PR DESCRIPTION
While filing and trying to fix #33, I noticed that linter-js-standard calls `standard` with the path to the source file, while it already has that file's contents in a variable. This patch just passes those contents via stdin, just like linter-jshint does. (That being said, it currently doesn't fix the original bug at all.) 

After this refactoring, I saw no need for caching `args` anymore, so I removed the related code. I have to say I don't really understand what the cache is supposed to do though. What's it caching exactly? Is it just trying to avoid array allocations? If so, I can't imagine that outweighing the overhead of creating a new process every time you lint.