### PR TITLE
Fixing check for gfm linting

### DIFF
--- a/lib/linter-js-standard.js
+++ b/lib/linter-js-standard.js
@@ -34,7 +34,7 @@ module.exports = function () {
       var settings = self.cache.get('text-editor')
       var config = self.cache.get('config')
 
-      if (this.grammarScopes.indexOf(fileScope) < 0 || (!config.lintMarkdownFiles && fileScope !== 'source.gfm')) {
+      if (this.grammarScopes.indexOf(fileScope) < 0 || (!config.lintMarkdownFiles && fileScope === 'source.gfm')) {
         return []
       }
 


### PR DESCRIPTION
Linting doesn't work any longer if Markdown linting is disabled.