### PR TITLE
:arrow_up: babel-eslint 4.1.1, standard 5.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "babel-eslint": "^3.1.20",
+    "babel-eslint": "^4.1.1",
     "esprima": "^2.4.1",
     "esprima-fb": "^15001.1.0-dev-harmony-fb",
     "find-root": "^0.1.1",
@@ -29,10 +29,7 @@
     "pkg-config": "^1.1.0",
     "q": "^1.4.1",
     "semistandard": "7.0.2",
-    "standard": "5.1.0"
-  },
-  "devDependencies": {
-    "standard": "^5.0.0"
+    "standard": "^5.2.1"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
The dev/3.x.x merge (a9a4c675c018370294c34ed12e9d920a72270030) and 3.x releases to npm downgraded the standard and babel-eslint versions (previously updated in PR #43).

This PR also removes the duplicate standard dependency in devDependencies.

Like, @chibicode, I need an updated version of standard and babel-eslint to fix the issue discussed in xjamundx/eslint-plugin-standard#3.