### PR TITLE
Fix #67 - tweak title and desc for checkStyle...

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -12,7 +12,8 @@ module.exports = {
     },
     checkStyleDevDependencies: {
       type: 'boolean',
-      description: 'Check code style on package.json devDependencies',
+      title: 'Check for standard',
+      description: 'Only run if standard, semistandard or happiness present in package.json `devDependencies`',
       default: false
     },
     honorStyleSettings: {


### PR DESCRIPTION
See #67 - This change preserves the original key name, so users existing settings won't be affected, and to limit the scope of the change on the plugin code. The `title` property will override the auto-generated key name.