### PR TITLE
Changes `semistandard` dependency to be a range

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "minimatch": "^2.0.8",
     "pkg-config": "^1.1.0",
     "q": "^1.4.1",
-    "semistandard": "7.0.2",
+    "semistandard": "^7.0.2",
     "standard": "5.2.1",
     "uber-standard": "^4.0.1"
   },


### PR DESCRIPTION
Version 7.0.2 of `semistandard` has some issues like https://github.com/Flet/semistandard/issues/38 and 7.0.3 fixes it. But since the module is required by exact version in `package.json`, the new version is not pulled from NPM.

This PR changes `package.json` to require `semistandard` as a range to include any bug fixes that may become available.