### PR TITLE
Updated happiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "esprima": "^2.4.1",
     "esprima-fb": "^15001.1.0-dev-harmony-fb",
     "find-root": "^0.1.1",
-    "happiness": "1.0.7",
+    "happiness": "^5.5.0",
     "lodash.intersection": "^3.2.0",
     "loophole": "^1.1.0",
     "minimatch": "^2.0.8",


### PR DESCRIPTION
We recently updated happiness to follow more closely with standard.  So pinning a version shouldn't be as important, so I changed it to the most recent major version range.  I dont have much experience with atom packages , so I don't know how to test it, but the api between `standard@5.2.1` should be the same as `happiness@5.5.0`.  If you have instructions on how I can run this branch on my atom install I would love to try to make sure it is all working.  Unless you are confident it is alright.  Thanks!