### PR TITLE
Definition for rule 'react/jsx-no-duplicate-props' was not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "minimatch": "^2.0.8",
     "pkg-config": "^1.1.0",
     "q": "^1.4.1",
-    "semistandard": "7.0.2",
+    "semistandard": "7.0.5",
     "standard": "5.2.1",
     "uber-standard": "^4.0.1"
   },


### PR DESCRIPTION
Bump `semistandard` version to 7.0.5, which contains fix for this issue