### PR TITLE
use the local linter version when possible

### DIFF
--- a/lib/utils/select-style.js
+++ b/lib/utils/select-style.js
@@ -1,22 +1,32 @@
 // Dependencies
 var allowUnsafeNewFunction = require('loophole').allowUnsafeNewFunction
-var pickStandard = function (style) {
+function requireWithLocalOverride (moduleName, dir) {
+  try {
+    return module.constructor._load(moduleName, {
+      paths: module.constructor._nodeModulePaths(dir)
+    })
+  } catch (err) {
+    return require(moduleName)
+  }
+}
+var pickStandard = function (style, dir) {
   return allowUnsafeNewFunction(function () {
     switch (style) {
       case 'standard':
-        return require('standard')
+        return requireWithLocalOverride('standard', dir)
       case 'happiness':
-        return require('happiness')
+        return requireWithLocalOverride('happiness', dir)
       case 'uber-standard':
-        return require('uber-standard')
+        return requireWithLocalOverride('uber-standard', dir)
       default:
-        return require('semistandard')
+        return requireWithLocalOverride('semistandard', dir)
     }
   })
 }
 
 var pkgConfig = require('pkg-config')
 var intersection = require('lodash.intersection')
+var dirname = require('path').dirname
 
 function getStyleThroughDevDeps (filePath) {
   // This will get the devDependencies
@@ -30,23 +40,25 @@ function getStyleThroughDevDeps (filePath) {
   var foundLinters = intersection(Object.keys(devDeps), knownLinters)
   var hasKnownLinter = Boolean(foundLinters.length)
   if (devDeps && hasKnownLinter) {
+    var dir = dirname(filePath)
+
     // standard style
     if (devDeps.standard) {
-      return pickStandard('standard')
+      return pickStandard('standard', dir)
     }
 
     // happiness style
     if (devDeps.happiness) {
-      return pickStandard('happiness')
+      return pickStandard('happiness', dir)
     }
 
     // uber-standard
     if (devDeps['uber-standard']) {
-      return pickStandard('uber-standard')
+      return pickStandard('uber-standard', dir)
     }
 
     // semistandard style
-    return pickStandard('semistandard')
+    return pickStandard('semistandard', dir)
   }
 
   // no style
@@ -63,16 +75,17 @@ module.exports = function selectStyle (config, filePath) {
   }
 
   function getLinterFromStyle (style) {
+    var dir = dirname(filePath)
     if (style === 'standard') {
-      return pickStandard('standard')
+      return pickStandard('standard', dir)
     }
     if (style === 'happiness') {
-      return pickStandard('happiness')
+      return pickStandard('happiness', dir)
     }
     if (style === 'uber-standard') {
-      return pickStandard('uber-standard')
+      return pickStandard('uber-standard', dir)
     }
-    return pickStandard('semistandard')
+    return pickStandard('semistandard', dir)
   }
 
   // fallback to style select value to decide which style


### PR DESCRIPTION
Solves #65 #89 #86 #76 #72 

Uses the linter your package depends on rather than the internal dependency whenever possible. This means that when you update standard in your package.json devDependencies, linter-js-standard will use that version. Also means that this package doesn't need to be updated constantly whenever a new version of anything comes out.