### PR TITLE
Fixed bug with missing package.json and dev deps

### DIFF
--- a/lib/utils/select-style.js
+++ b/lib/utils/select-style.js
@@ -32,14 +32,18 @@ function getStyleThroughDevDeps (filePath) {
   // This will get the devDependencies
   // from the nearest package.json
   var options = { cwd: filePath, root: 'devDependencies', cache: false }
+  var noStyle = { cmd: 'no-style' }
   var devDeps = pkgConfig(null, options)
+
+  // No devDependencies found
+  if (!devDeps) return noStyle
 
   // Check if there are linters defined in
   // package.json devDependencies
   var knownLinters = ['standard', 'semistandard', 'happiness', 'uber-standard']
   var foundLinters = intersection(Object.keys(devDeps), knownLinters)
   var hasKnownLinter = Boolean(foundLinters.length)
-  if (devDeps && hasKnownLinter) {
+  if (hasKnownLinter) {
     var dir = dirname(filePath)
 
     // standard style
@@ -62,9 +66,7 @@ function getStyleThroughDevDeps (filePath) {
   }
 
   // no style
-  return {
-    cmd: 'no-style'
-  }
+  return noStyle
 }
 
 module.exports = function selectStyle (config, filePath) {


### PR DESCRIPTION
This should solve #102 which made the package crash when we're opening files in projects with no `package.json` or no `devDependencies`.