### PR TITLE
semistandard needs to use v7.0.3 because it always errors out wheneve…

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "minimatch": "^2.0.8",
     "pkg-config": "^1.1.0",
     "q": "^1.4.1",
-    "semistandard": "7.0.2",
+    "semistandard": "7.0.3",
     "standard": "5.2.1",
     "uber-standard": "^4.0.1"
   },


### PR DESCRIPTION
semistandard needs to use v7.0.3 because it always errors out and gives me "Definition for rule 'react/jsx-no-duplicate-props' was not found" whenever linter-js-standard updates, at least in my case