### PR TITLE
Resolve issue #62

### DIFF
--- a/lib/utils/style-settings.js
+++ b/lib/utils/style-settings.js
@@ -1,5 +1,5 @@
+/* global atom */
 // Dependencies
-var findRoot = require('find-root')
 var minimatch = require('minimatch')
 var pkgConfig = require('pkg-config')
 
@@ -11,8 +11,22 @@ module.exports = function checkStyleSettings (filePath) {
   // NOTE: the project's path returned will be
   // from the nearest package.json (direction upward)
   try {
-    var projectPath = findRoot(filePath)
+    var projectPath
+    var projectPaths = atom.project.findPaths()
+    var projectPathCount = projectPaths.length
+    for (var i = 0; i < projectPathCount; i++) {
+      if (atom.workspace.getActiveTextEditor().getPath().indexOf(projectPaths[i]) >= 0) {
+        projectPath = projectPaths[i]
+      }
+    }
+    if (!projectPath) {
+      return atom.notifications.addWarning('Could not get the file path.', {
+        detail: 'No sweat, just save this file and this annoying warning shouldn\'t appear anymore',
+        dismissable: true
+      })
+    }
   } catch (e) {
+    console.error('Could not get project path', e)
     return
   }
 


### PR DESCRIPTION
Handle projectPath using atom api instead of find root package with
additional checks to resolve issue #62:
”Uncaught TypeError: Cannot read property 'replace' of undefined" when
attempting to close tab #62