### PR TITLE
Add support for eslint 'env' configuration

### DIFF
--- a/lib/utils/style-settings.js
+++ b/lib/utils/style-settings.js
@@ -93,5 +93,17 @@ module.exports = function checkStyleSettings (filePath) {
         this.args.globals.push(item)
       }.bind(this))
     }
+
+    if (styleSettings.env) {
+      for (let envKey in styleSettings.env) {
+        if (!styleSettings.env.hasOwnProperty(envKey)) {
+          continue
+        }
+        if (!this.args.env) {
+          this.args.env = {}
+        }
+        this.args.env[envKey] = styleSettings.env[envKey]
+      }
+    }
   }
 }


### PR DESCRIPTION
While it's nice to have the package.json `standard.globals` options being merged into the Standard initialisation, Standard also supports passing 'env' down to ESLint, which lets you set common collections of globals.

For example, the following config:

```json
// ...
"standard": {
  "env": {
    "mocha": true
  }
}
// ...
```

... adds Mocha's globals (describe, it, before, after, beforeEach, afterEach, xit, etc) in one key.