### PR TITLE
Look for linters in dependencies as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Custom parsers currently supported:
 ## Settings
 
 ### checkStyleDevDependencies (default: false)
-Check code style in package.json `devDependencies`. If a valid style is not found it won't lint.
+Check code style in package.json `devDependencies` or `dependencies`. If a valid style is not found it won't lint.
 
 > Note: This will use the nearest package.json.
 

--- a/lib/init.js
+++ b/lib/init.js
@@ -13,7 +13,7 @@ module.exports = {
     checkStyleDevDependencies: {
       type: 'boolean',
       title: 'Check for standard',
-      description: 'Only run if standard, semistandard or happiness present in package.json `devDependencies`',
+      description: 'Only run if standard, semistandard or happiness present in package.json `devDependencies` or `dependencies`',
       default: false
     },
     honorStyleSettings: {

--- a/lib/utils/select-style.js
+++ b/lib/utils/select-style.js
@@ -34,6 +34,7 @@ function getStyleThroughDevDeps (filePath) {
   var options = { cwd: filePath, root: 'devDependencies', cache: false }
   var noStyle = { cmd: 'no-style' }
   var devDeps = pkgConfig(null, options)
+  var prodDeps = pkgConfig(null, Object.assign({}, options, { root: 'dependencies' }))
 
   // No devDependencies found
   if (!devDeps) return noStyle
@@ -41,23 +42,24 @@ function getStyleThroughDevDeps (filePath) {
   // Check if there are linters defined in
   // package.json devDependencies
   var knownLinters = ['standard', 'semistandard', 'happiness', 'uber-standard']
-  var foundLinters = intersection(Object.keys(devDeps), knownLinters)
-  var hasKnownLinter = Boolean(foundLinters.length)
+  var foundDevLinters = intersection(Object.keys(devDeps), knownLinters)
+  var foundProdLinters = intersection(Object.keys(prodDeps), knownLinters)
+  var hasKnownLinter = Boolean(foundDevLinters.length) || Boolean(foundProdLinters.length)
   if (hasKnownLinter) {
     var dir = dirname(filePath)
 
     // standard style
-    if (devDeps.standard) {
+    if (devDeps.standard || prodDeps.standard) {
       return pickStandard('standard', dir)
     }
 
     // happiness style
-    if (devDeps.happiness) {
+    if (devDeps.happiness || prodDeps.happiness) {
       return pickStandard('happiness', dir)
     }
 
     // uber-standard
-    if (devDeps['uber-standard']) {
+    if (devDeps['uber-standard'] || prodDeps['uber-standard']) {
       return pickStandard('uber-standard', dir)
     }
 


### PR DESCRIPTION
I'm writing a cli tool where we need to include standard in `dependencies` since there will be a `format` command that uses standard with the `--format` flag. This adds a check to look in `dependencies` along with `devDependencies`.