### PR TITLE
fix: Markdown splitter is not greedy

### DIFF
--- a/lib/utils/markdown-splitter.js
+++ b/lib/utils/markdown-splitter.js
@@ -1,28 +1,30 @@
 module.exports = function (fileContent) {
-  var startFencedCodeRegex = /(```js[ ]*)$/gm
-  var stopFencedCodeRegex = /(```[ ]*)$/gm
+  var startFencedCodeRegex = /(```\s*js\s*)$/gm
+  var stopFencedCodeRegex = /(```\s*)$/gm
   var blocks = []
-  var lineTracker = 1
+  var offset = 0
 
   var splitterRecursive = function () {
+    startFencedCodeRegex.lastIndex = offset
+
     var start = startFencedCodeRegex.exec(fileContent)
 
     if (start) {
       var contentCutted = fileContent.substring(0, start.index)
-      fileContent = fileContent.substring(start.index)
+
+      stopFencedCodeRegex.lastIndex = contentCutted.length
+
       var end = stopFencedCodeRegex.exec(fileContent)
 
       if (!end) {
         return false
       }
 
-      lineTracker += contentCutted.split('\n').length - 1
-
-      var line = lineTracker
-      var content = fileContent.substring(start[0].length + 1, end.index - 1)
+      var content = fileContent.substring(contentCutted.length + start[0].length, end.index).trimRight() + '\n'
+      offset = end.index
 
       blocks.push({
-        line: line,
+        line: contentCutted.split('\n').length - 1,
         content: content
       })
 


### PR DESCRIPTION
- Fix the open block regex to allow space before the language selector (js)
- Fix the parser to extract more than only the first code block 
  (currently, the parser fails to find more than one code block)