### PR TITLE
feat: Lint html embedded script blocks (fix #100)

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -13,7 +13,7 @@ module.exports = {
     checkStyleDevDependencies: {
       type: 'boolean',
       title: 'Check for standard',
-      description: 'Only run if standard, semistandard or happiness present in package.json `devDependencies` or `dependencies`',
+      description: 'Only run if standard, semistandard or happiness present in package.json `devDependencies`',
       default: false
     },
     honorStyleSettings: {
@@ -29,6 +29,11 @@ module.exports = {
     lintMarkdownFiles: {
       type: 'boolean',
       description: 'Lint markdown fenced code blocks',
+      default: false
+    },
+    lintHtmlFiles: {
+      type: 'boolean',
+      description: 'Lint html-embedded script blocks',
       default: false
     }
   },
@@ -56,6 +61,16 @@ module.exports = {
 
         // Check if this file is inside our grammar scope
         var grammar = paneItem.getGrammar() || { scopeName: null }
+
+        // Check if this file is inside any kind of html scope (such as text.html.basic among others)
+        if (config.lintHtmlFiles && /^text.html/.test(grammar.scopeName) && self.scope.indexOf(grammar.scopeName) < 0) {
+          self.scope.push(grammar.scopeName)
+        }
+
+        if (!config.lintHtmlFiles && /^text.html/.test(grammar.scopeName)) {
+          return
+        }
+
         if (self.scope.indexOf(grammar.scopeName) < 0 || (!config.lintMarkdownFiles && grammar.scopeName === 'source.gfm')) {
           return
         }

--- a/lib/linter-js-standard.js
+++ b/lib/linter-js-standard.js
@@ -2,6 +2,7 @@
 var linter = require('./utils/linter')
 var allowUnsafeNewFunction = require('loophole').allowUnsafeNewFunction
 var markdownSplitter = require('./utils/markdown-splitter')
+var htmlSplitter = require('./utils/html-splitter')
 var Q = require('q')
 
 function generateLintPromise (filePath, fileContent, settings, config, lineStart) {
@@ -35,6 +36,10 @@ module.exports = function () {
       var settings = self.cache.get('text-editor')
       var config = self.cache.get('config')
 
+      if (!config.lintHtmlFiles && /^text\.html/.test(fileScope)) {
+        return []
+      }
+
       if (this.grammarScopes.indexOf(fileScope) < 0 || (!config.lintMarkdownFiles && fileScope === 'source.gfm')) {
         return []
       }
@@ -58,6 +63,11 @@ module.exports = function () {
       if (fileScope === 'source.gfm') {
         var fencedCodeBlocks = markdownSplitter(fileContent)
         fencedCodeBlocks.forEach(function (block) {
+          lintPromises.push(generateLintPromise(filePath, block.content, settings, config, block.line))
+        })
+      } else if (/^text\.html/.test(fileScope)) {
+        var scriptCodeBlocks = htmlSplitter(fileContent)
+        scriptCodeBlocks.forEach(function (block) {
           lintPromises.push(generateLintPromise(filePath, block.content, settings, config, block.line))
         })
       } else {

--- a/lib/utils/html-splitter.js
+++ b/lib/utils/html-splitter.js
@@ -1,0 +1,40 @@
+module.exports = function (fileContent) {
+  var startScriptCodeRegex = /(<script[^>]*>)$/gm
+  var stopScriptCodeRegex = /(<\/script>)$/gm
+  var blocks = []
+  var offset = 0
+
+  var splitterRecursive = function () {
+    startScriptCodeRegex.lastIndex = offset
+
+    var start = startScriptCodeRegex.exec(fileContent)
+
+    if (start) {
+      var contentCutted = fileContent.substring(0, start.index)
+
+      stopScriptCodeRegex.lastIndex = contentCutted.length
+
+      var end = stopScriptCodeRegex.exec(fileContent)
+
+      if (!end) {
+        return false
+      }
+
+      var content = fileContent.substring(contentCutted.length + start[0].length, end.index).trimRight() + '\n'
+      offset = end.index
+
+      blocks.push({
+        line: contentCutted.split('\n').length - 1,
+        content: content
+      })
+
+      return true
+    }
+
+    return false
+  }
+
+  while (splitterRecursive()) {}
+
+  return blocks
+}


### PR DESCRIPTION
Add an option, and a block extractor, to lint
embedded script (for any source with a scopeName beginning with
`text.html`)

Could be considered as experimental... Seems to works nice with
basic html and component files like [vuejs component files](https://vuejs.org/guide/application.html#Single-File-Components)