### PR TITLE
Support standard-flow linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ linter-js-standard
 =========================
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://github.com/feross/standard)
 
-This plugin for [Linter](https://github.com/AtomLinter/Linter) provides an interface for error/warning messages from [standard](https://github.com/feross/standard), [semistandard](https://github.com/Flet/semistandard) or [happiness](https://github.com/JedWatson/happiness).
+This plugin for [Linter](https://github.com/AtomLinter/Linter) provides an interface for error/warning messages from [standard](https://github.com/feross/standard), [semistandard](https://github.com/Flet/semistandard), [happiness](https://github.com/JedWatson/happiness) or [standard-flow](https://github.com/Gozala/standard-flow).
 
 ![demo](https://cloud.githubusercontent.com/assets/6867996/8457085/4bd7575e-2007-11e5-9762-e3f942b78232.gif)
 
@@ -15,7 +15,7 @@ $ apm install linter-js-standard
 ```
 
 ## Features
-- Support `standard`, `semistandard` and `happiness` styles.
+- Support `standard`, `semistandard`, `happiness` and `standard-flow` styles.
 - Support ignore glob patterns in package.json.
 - Support custom parsers in package.json.
 - Support global variables in package.json _(supported by standard and semistandard)_

--- a/lib/init.js
+++ b/lib/init.js
@@ -8,12 +8,12 @@ module.exports = {
     style: {
       type: 'string',
       default: 'standard',
-      enum: ['standard', 'semi-standard', 'happiness', 'uber-standard']
+      enum: ['standard', 'semi-standard', 'happiness', 'uber-standard', 'standard-flow']
     },
     checkStyleDevDependencies: {
       type: 'boolean',
       title: 'Check for standard',
-      description: 'Only run if standard, semistandard or happiness present in package.json `devDependencies`',
+      description: 'Only run if standard, semistandard, happiness, uber-standard or standard-flow present in package.json `devDependencies`',
       default: false
     },
     honorStyleSettings: {

--- a/lib/utils/select-style.js
+++ b/lib/utils/select-style.js
@@ -18,6 +18,8 @@ var pickStandard = function (style, dir) {
         return requireWithLocalOverride('happiness', dir)
       case 'uber-standard':
         return requireWithLocalOverride('uber-standard', dir)
+      case 'standard-flow':
+        return requireWithLocalOverride('standard-flow', dir)
       default:
         return requireWithLocalOverride('semistandard', dir)
     }
@@ -38,7 +40,7 @@ function getStyleThroughDevDeps (filePath) {
 
   // Check if there are linters defined in
   // package.json devDependencies
-  var knownLinters = ['standard', 'semistandard', 'happiness', 'uber-standard']
+  var knownLinters = ['standard', 'semistandard', 'happiness', 'uber-standard', 'standard-flow']
   var foundDevLinters = intersection(Object.keys(devDeps), knownLinters)
   var foundProdLinters = intersection(Object.keys(prodDeps), knownLinters)
   var hasKnownLinter = Boolean(foundDevLinters.length) || Boolean(foundProdLinters.length)
@@ -58,6 +60,11 @@ function getStyleThroughDevDeps (filePath) {
     // uber-standard
     if (devDeps['uber-standard'] || prodDeps['uber-standard']) {
       return pickStandard('uber-standard', dir)
+    }
+
+    // standard-flow
+    if (devDeps['standard-flow'] || prodDeps['standard-flow']) {
+      return pickStandard('standard-flow', dir)
     }
 
     // semistandard style
@@ -85,6 +92,9 @@ module.exports = function selectStyle (config, filePath) {
     }
     if (style === 'uber-standard') {
       return pickStandard('uber-standard', dir)
+    }
+    if (style === 'standard-flow') {
+      return pickStandard('standard-flow', dir)
     }
     return pickStandard('semistandard', dir)
   }

--- a/lib/utils/style-settings.js
+++ b/lib/utils/style-settings.js
@@ -46,6 +46,11 @@ module.exports = function checkStyleSettings (filePath) {
       styleSettings = pkgConfig(null, options)
       break
 
+    case 'standard-flow':
+      options.root = 'standard-flow'
+      styleSettings = pkgConfig(null, options)
+      break
+
     default:
       throw new Error('Something went wrong.')
   }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "q": "^1.4.1",
     "semistandard": "^9.1.0",
     "standard": "^8.6.0",
+    "standard-flow": "^1.0.0",
     "uber-standard": "^5.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Having standard support in atom is great (I use it in all of my projects), but unfortunately it doesn't play well with [Flow](https://flowtype.org/). This PR adds support for standard-flow, so that now we can have standard linting *and* static type checking! 🎉 

Please let me know if there are any edits I need to make before this gets merged, thanks!