### PR TITLE
fix checkStyleSettings when path not found

### DIFF
--- a/lib/utils/style-settings.js
+++ b/lib/utils/style-settings.js
@@ -39,7 +39,7 @@ function checkStyleSettings (filePath) {
     projectPath = projectPaths.find((p) => absoluteActivePanePath.indexOf(fs.realpathSync(p)) >= 0)
   } catch (e) {
     console.error('Could not get project path', e)
-    return
+    return {}
   }
 
   var relativeFilePath = false


### PR DESCRIPTION
Open files in atom can be moved or deleted. When nonexistant files are listed, `checkStyleSettings` to returns `undefined` which causes #168. For now, I returned an empty object even when `checkStyleSettings` swallows any file read error.