### PR TITLE
Assign values to the 'text-editor' key if necessary

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -84,6 +84,9 @@ module.exports = {
       // if it is cache it's settings
       var paneItem = atom.workspace.getActivePaneItem()
       storeSettings(paneItem)
+      if (!self.cache.get('text-editor')) {
+        self.cache.set('text-editor', { style: { cmd: 'no-style' }, opts: {} })
+      }
 
       // Create some subscriptions
       self.subscriptions = new CompositeDisposable()


### PR DESCRIPTION
I think this will solve the issue #179. 

Whenever a text editor panel is activated, the 'lint' function (lib/linter-js-standard.js) checks if 'text-editor' key has values. But if there isn't any active text editor when Atom starts, the 'activate' function (lib/init.js) won't assign any value to the 'text-editor' key. 

Basically the warning would always show up if Atom didn't initialize with an active text editor.