### PR TITLE
Update atom-package-deps to v4.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "atom-package-deps": "^2.0.5",
+    "atom-package-deps": "^4.6.0",
     "babel-eslint": "^7.1.0",
     "esprima": "^3.1.1",
     "esprima-fb": "^15001.1001.0-dev-harmony-fb",


### PR DESCRIPTION
Updates the minimum version of `atom-package-deps` to v4.6.0.

Fixes #187.