### PR TITLE
Added option to display just fatal errors by ignoring warnings

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -10,6 +10,12 @@ module.exports = {
       default: styleSettings.defaultStyle,
       enum: styleSettings.styleOptions
     },
+    displayWarnings: {
+      type: 'boolean',
+      title: 'Display Warnings',
+      description: 'When enabled this will display the JS linter warning in addition to the Errors',
+      default: true
+    },
     checkStyleDevDependencies: {
       type: 'boolean',
       title: 'Check for standard',
@@ -50,12 +56,17 @@ module.exports = {
       var config = atom.config.get('linter-js-standard')
       self.cache.set('config', config)
 
-      var storeSettings = function (textEditor) {
+      var storeSettings = function (paneItem) {
+        // Check if the pane is a file
+        if (!self.__checkIfTextEditor(paneItem)) {
+          return
+        }
+
         // Get config
         var config = self.cache.get('config')
 
         // Check if this file is inside our grammar scope
-        var grammar = textEditor.getGrammar() || { scopeName: null }
+        var grammar = paneItem.getGrammar() || { scopeName: null }
 
         // Check if this file is inside any kind of html scope (such as text.html.basic among others)
         if (config.lintHtmlFiles && /^text.html/.test(grammar.scopeName) && self.scope.indexOf(grammar.scopeName) < 0) {
@@ -70,14 +81,20 @@ module.exports = {
           return
         }
 
-        // Cache text editor
-        self.__cacheTextEditor(config, textEditor)
+        // Cache active pane
+        self.__cacheTextEditor(config, paneItem)
       }
+
+      // On startup get active pane
+      // check if it's a text editor
+      // if it is cache it's settings
+      var paneItem = atom.workspace.getActivePaneItem()
+      storeSettings(paneItem)
 
       // Create some subscriptions
       self.subscriptions = new CompositeDisposable()
 
-      self.subscriptions.add(atom.workspace.observeTextEditors(storeSettings))
+      self.subscriptions.add(atom.workspace.onDidChangeActivePaneItem(storeSettings))
 
       // on package settings change
       self.subscriptions.add(atom.config.observe('linter-js-standard', function (config) {
@@ -94,7 +111,7 @@ module.exports = {
   __cacheTextEditor: function (config, textEditor) {
     var filePath = textEditor.getPath()
 
-    var opts = config.honorStyleSettings ? styleSettings.checkStyleSettings(filePath, textEditor) : {}
+    var opts = config.honorStyleSettings ? styleSettings.checkStyleSettings(filePath) : {}
 
     var style = selectStyle(filePath, {
       style: opts.style || config.style,
@@ -103,6 +120,10 @@ module.exports = {
 
     // Cache style settings and args of some file
     this.cache.set('text-editor', { style: style, opts: opts })
+  },
+
+  __checkIfTextEditor: function (paneItem) {
+    return (paneItem && typeof paneItem.getGrammar === 'function' && typeof paneItem.getPath === 'function')
   },
 
   provideLinter: require('./linter-js-standard')

--- a/lib/init.js
+++ b/lib/init.js
@@ -56,17 +56,12 @@ module.exports = {
       var config = atom.config.get('linter-js-standard')
       self.cache.set('config', config)
 
-      var storeSettings = function (paneItem) {
-        // Check if the pane is a file
-        if (!self.__checkIfTextEditor(paneItem)) {
-          return
-        }
-
+      var storeSettings = function (textEditor) {
         // Get config
         var config = self.cache.get('config')
 
         // Check if this file is inside our grammar scope
-        var grammar = paneItem.getGrammar() || { scopeName: null }
+        var grammar = textEditor.getGrammar() || { scopeName: null }
 
         // Check if this file is inside any kind of html scope (such as text.html.basic among others)
         if (config.lintHtmlFiles && /^text.html/.test(grammar.scopeName) && self.scope.indexOf(grammar.scopeName) < 0) {
@@ -81,20 +76,14 @@ module.exports = {
           return
         }
 
-        // Cache active pane
-        self.__cacheTextEditor(config, paneItem)
+        // Cache text editor
+        self.__cacheTextEditor(config, textEditor)
       }
-
-      // On startup get active pane
-      // check if it's a text editor
-      // if it is cache it's settings
-      var paneItem = atom.workspace.getActivePaneItem()
-      storeSettings(paneItem)
 
       // Create some subscriptions
       self.subscriptions = new CompositeDisposable()
 
-      self.subscriptions.add(atom.workspace.onDidChangeActivePaneItem(storeSettings))
+      self.subscriptions.add(atom.workspace.observeTextEditors(storeSettings))
 
       // on package settings change
       self.subscriptions.add(atom.config.observe('linter-js-standard', function (config) {
@@ -111,7 +100,7 @@ module.exports = {
   __cacheTextEditor: function (config, textEditor) {
     var filePath = textEditor.getPath()
 
-    var opts = config.honorStyleSettings ? styleSettings.checkStyleSettings(filePath) : {}
+    var opts = config.honorStyleSettings ? styleSettings.checkStyleSettings(filePath, textEditor) : {}
 
     var style = selectStyle(filePath, {
       style: opts.style || config.style,
@@ -120,10 +109,6 @@ module.exports = {
 
     // Cache style settings and args of some file
     this.cache.set('text-editor', { style: style, opts: opts })
-  },
-
-  __checkIfTextEditor: function (paneItem) {
-    return (paneItem && typeof paneItem.getGrammar === 'function' && typeof paneItem.getPath === 'function')
   },
 
   provideLinter: require('./linter-js-standard')

--- a/lib/utils/linter.js
+++ b/lib/utils/linter.js
@@ -20,13 +20,14 @@ module.exports = function (err, output) {
     if (self.config.showEslintRules) {
       msg.message += ' (' + msg.ruleId + ')'
     }
-
-    occurrences.push({
-      type: msg.fatal ? 'Error' : 'Warning',
-      text: msg.message,
-      filePath: self.filePath,
-      range: getRange(msg.line, msg.column, msg.source, self.lineStart)
-    })
+    if(self.config.displayWarnings || msg.fatal) {
+       occurrences.push({
+        type: msg.fatal ? 'Error' : 'Warning',
+        text: msg.message,
+        filePath: self.filePath,
+        range: getRange(msg.line, msg.column, msg.source, self.lineStart)
+      })
+    }
   })
 
   return this.deferred.resolve(occurrences)


### PR DESCRIPTION
I added in a new option so that JS warnings (like formatting warnings) can be turned off and just fatal warnings are displayed

Let me know if you have any questions
Thanks!
Todd