### PR TITLE
disable if eslint config is present

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -16,6 +16,12 @@ module.exports = {
       description: 'Only run if standard, semistandard or happiness present in package.json `devDependencies`',
       default: false
     },
+    checkForEslintConfig: {
+      type: 'boolean',
+      title: 'Disable if eslint is detected',
+      description: 'Do not run if there is an eslint config file in project, or `eslintConfig` section in `package.json`',
+      default: true
+    },
     honorStyleSettings: {
       type: 'boolean',
       description: 'Honor code style settings on package.json',
@@ -98,7 +104,8 @@ module.exports = {
 
     var style = selectStyle(filePath, {
       style: opts.style || config.style,
-      checkStyleDevDependencies: config.checkStyleDevDependencies
+      checkStyleDevDependencies: config.checkStyleDevDependencies,
+      checkForEslintConfig: config.checkForEslintConfig
     })
 
     // Cache style settings and args of some file

--- a/lib/init.js
+++ b/lib/init.js
@@ -18,8 +18,8 @@ module.exports = {
     },
     checkForEslintConfig: {
       type: 'boolean',
-      title: 'Disable if eslint is detected',
-      description: 'Do not run if there is an eslint config file in project, or `eslintConfig` section in `package.json`',
+      title: 'Disable if the project uses ESLint',
+      description: 'Do not run if the project has configured ESLint',
       default: true
     },
     honorStyleSettings: {

--- a/lib/utils/select-style.js
+++ b/lib/utils/select-style.js
@@ -49,7 +49,7 @@ function getStyleThroughDevDeps (filePath, style) {
 }
 
 module.exports = function selectStyle (filePath, options) {
-  // Escape early if the project has eslint configuration
+  // Return early if the project uses ESLint
   if (options.checkForEslintConfig && detectEslintConfig(filePath)) {
     return noStyle()
   }

--- a/lib/utils/select-style.js
+++ b/lib/utils/select-style.js
@@ -1,7 +1,17 @@
 var allowUnsafeNewFunction = require('loophole').allowUnsafeNewFunction
 var pkgConfig = require('pkg-config')
+var findRoot = require('find-root')
 var dirname = require('path').dirname
+var existsSync = require('fs').existsSync
 var styleSettings = require('./style-settings')
+var eslintFilename = '.eslintrc'
+var eslintExtensions = [
+  '',
+  '.js',
+  '.yaml',
+  '.yml'
+]
+var eslintConfigRoot = 'eslintConfig'
 
 function noStyle () {
   return { cmd: 'no-style' }
@@ -21,6 +31,22 @@ var pickStandard = function (style, filePath) {
   var dir = dirname(filePath)
   return allowUnsafeNewFunction(function () {
     return requireWithLocalOverride(style, dir)
+  })
+}
+
+function checkForEslintConfig (filePath) {
+  var eslintPkgConfig = pkgConfig(null, {
+    cwd: filePath,
+    root: eslintConfigRoot,
+    cache: false
+  })
+
+  var rootDir = findRoot(dirname(filePath))
+
+  if (eslintPkgConfig) return true
+
+  return eslintExtensions.some(function (extension) {
+    return existsSync(rootDir + '/' + eslintFilename + extension)
   })
 }
 
@@ -51,6 +77,12 @@ module.exports = function selectStyle (filePath, options) {
   // See if it should get style from the package.json
   if (options.checkStyleDevDependencies) {
     return getStyleThroughDevDeps(filePath, options.style)
+  }
+
+  if (options.checkForEslintConfig) {
+    if (checkForEslintConfig(filePath)) {
+      return noStyle()
+    }
   }
 
   // Fallback to style value to decide which style we should use

--- a/lib/utils/select-style.js
+++ b/lib/utils/select-style.js
@@ -1,17 +1,8 @@
 var allowUnsafeNewFunction = require('loophole').allowUnsafeNewFunction
 var pkgConfig = require('pkg-config')
-var findRoot = require('find-root')
+var detectEslintConfig = require('detect-eslint-config')
 var dirname = require('path').dirname
-var existsSync = require('fs').existsSync
 var styleSettings = require('./style-settings')
-var eslintFilename = '.eslintrc'
-var eslintExtensions = [
-  '',
-  '.js',
-  '.yaml',
-  '.yml'
-]
-var eslintConfigRoot = 'eslintConfig'
 
 function noStyle () {
   return { cmd: 'no-style' }
@@ -31,22 +22,6 @@ var pickStandard = function (style, filePath) {
   var dir = dirname(filePath)
   return allowUnsafeNewFunction(function () {
     return requireWithLocalOverride(style, dir)
-  })
-}
-
-function checkForEslintConfig (filePath) {
-  var eslintPkgConfig = pkgConfig(null, {
-    cwd: filePath,
-    root: eslintConfigRoot,
-    cache: false
-  })
-
-  var rootDir = findRoot(dirname(filePath))
-
-  if (eslintPkgConfig) return true
-
-  return eslintExtensions.some(function (extension) {
-    return existsSync(rootDir + '/' + eslintFilename + extension)
   })
 }
 
@@ -74,15 +49,14 @@ function getStyleThroughDevDeps (filePath, style) {
 }
 
 module.exports = function selectStyle (filePath, options) {
+  // Escape early if the project has eslint configuration
+  if (options.checkForEslintConfig && detectEslintConfig(filePath)) {
+    return noStyle()
+  }
+
   // See if it should get style from the package.json
   if (options.checkStyleDevDependencies) {
     return getStyleThroughDevDeps(filePath, options.style)
-  }
-
-  if (options.checkForEslintConfig) {
-    if (checkForEslintConfig(filePath)) {
-      return noStyle()
-    }
   }
 
   // Fallback to style value to decide which style we should use

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-eslint": "^7.1.0",
     "eslint-rule-documentation": "^1.0.9",
     "esprima": "^3.1.1",
+    "find-root": "^1.1.0",
     "happiness": "^10.0.2",
     "loophole": "^1.1.0",
     "minimatch": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   "dependencies": {
     "atom-package-deps": "^4.6.0",
     "babel-eslint": "^7.1.0",
+    "detect-eslint-config": "^0.5.6",
     "eslint-rule-documentation": "^1.0.9",
     "esprima": "^3.1.1",
-    "find-root": "^1.1.0",
     "happiness": "^10.0.2",
     "loophole": "^1.1.0",
     "minimatch": "^3.0.4",


### PR DESCRIPTION
closes #194

works for me
ready to make any fixes necessary

now i can leave `linter-js-standard` and `linter-eslint` enabled and comfortably switch between projects 

💚❤️💜💛 ｡^‿^｡ 💛💜❤️💚